### PR TITLE
Move the err to OSInfo struct

### DIFF
--- a/osinfo.go
+++ b/osinfo.go
@@ -11,17 +11,19 @@ const (
 type OSInfo struct {
 	Name    string `json:"os" yaml:"os"`
 	Version string `json:"version" yaml:"version"`
+	err     error
 }
 
 func (oi *OSInfo) String() string {
 	return fmt.Sprintf("%s %s", oi.Name, oi.Version)
 }
 
+func (oi *OSInfo) Err() error {
+	return oi.err
+}
+
 // Release returns release version of current running OS. It returns a
 // default string if can't find.
 func Release() string {
-	if oi, err := New(); err == nil {
-		return oi.Version
-	}
-	return UnknownRelease
+	return New().Version
 }

--- a/osinfo_android.go
+++ b/osinfo_android.go
@@ -14,13 +14,15 @@ const (
 )
 
 // New returns an instance of OSInfo.
-func New() (oi *OSInfo, err error) {
+func New() (oi *OSInfo) {
 	oi = &OSInfo{
-		Name: runtime.GOOS,
+		Name:    runtime.GOOS,
+		Version: UnknownRelease,
 	}
 
 	f, err := os.Open(buildPropPath)
 	if err != nil {
+		oi.err = err
 		return
 	}
 	defer f.Close()
@@ -35,7 +37,7 @@ func New() (oi *OSInfo, err error) {
 	}
 
 	if len(oi.Version) == 0 {
-		err = fmt.Errorf("property not found: %s", releasePrefix)
+		oi.err = fmt.Errorf("property not found: %s", releasePrefix)
 	}
 	return
 }

--- a/osinfo_darwin.go
+++ b/osinfo_darwin.go
@@ -8,15 +8,17 @@ import (
 )
 
 // New returns an instance of OSInfo.
-func New() (oi *OSInfo, err error) {
+func New() (oi *OSInfo) {
 	oi = &OSInfo{
-		Name: runtime.GOOS,
+		Name:    runtime.GOOS,
+		Version: UnknownRelease,
 	}
 
 	cmd := exec.Command("/usr/bin/sw_vers", "-productVersion")
 	var out bytes.Buffer
 	cmd.Stdout = &out
-	if err = cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil {
+		oi.err = err
 		return
 	}
 	oi.Version = strings.TrimSpace(out.String())

--- a/osinfo_linux.go
+++ b/osinfo_linux.go
@@ -11,16 +11,18 @@ import (
 )
 
 // New returns an instance of OSInfo.
-func New() (oi *OSInfo, err error) {
+func New() (oi *OSInfo) {
 	oi = &OSInfo{
-		Name: runtime.GOOS,
+		Name:    runtime.GOOS,
+		Version: UnknownRelease,
 	}
 
 	// kernel vesion
 	unameCmd := exec.Command("uname", "--kernel-release")
 	var unameOut bytes.Buffer
 	unameCmd.Stdout = &unameOut
-	if err = unameCmd.Run(); err != nil {
+	if err := unameCmd.Run(); err != nil {
+		oi.err = err
 		return
 	}
 	kernelRelease := strings.TrimSpace(unameOut.String())
@@ -29,12 +31,14 @@ func New() (oi *OSInfo, err error) {
 	lsbPath, err := exec.LookPath("lsb_release")
 	if err != nil { // lsb_release is not installed, returns kernel release
 		oi.Version = kernelRelease
+		oi.err = err
 		return
 	}
 	lsbCmd := exec.Command(lsbPath, "--description")
 	var lsbOut bytes.Buffer
 	lsbCmd.Stdout = &lsbOut
-	if err = lsbCmd.Run(); err != nil {
+	if err := lsbCmd.Run(); err != nil {
+		oi.err = err
 		return
 	}
 	desc := lsbOut.String()

--- a/osinfo_test.go
+++ b/osinfo_test.go
@@ -3,8 +3,8 @@ package osinfo
 import "testing"
 
 func TestOSInfo(t *testing.T) {
-	oi, err := New()
-	if err != nil {
+	oi := New()
+	if err := oi.Err(); err != nil {
 		t.Fatal(err)
 	}
 	t.Log(oi)

--- a/osinfo_windows.go
+++ b/osinfo_windows.go
@@ -7,24 +7,26 @@ import (
 )
 
 // New returns an instance of OSInfo.
-func New() (oi *OSInfo, err error) {
+func New() (oi *OSInfo) {
 	oi = &OSInfo{
-		Name: runtime.GOOS,
+		Name:    runtime.GOOS,
+		Version: UnknownRelease,
 	}
 
 	dll := syscall.MustLoadDLL("kernel32.dll")
 	p, err := dll.FindProc("GetVersion")
 	if err != nil {
+		oi.err = err
 		return
 	}
 	v, _, err := p.Call()
 	// err is always non-nil, if v is zero, it is an error.
 	version := uint32(v)
 	if version == 0 {
+		oi.err = err
 		return
-	} else {
-		err = nil
 	}
+
 	oi.Version = fmt.Sprintf("%d.%d", byte(v), uint8(v>>8))
 	return
 }


### PR DESCRIPTION
Currently, New always return a non-nil OSInfo even when error occurred.
That against the idiom that when error occurred, the return value should
be nil for pointer type.

Since when the caller always get a non-nil OSInfo, this commit makes the
error as a property of OSInfo. The caller can call OSInfo.Err() to check
whether an error occurred or not.